### PR TITLE
Feature/101-v2-set-up-search-endpoint-for-events

### DIFF
--- a/intavia_backend/main_v2.py
+++ b/intavia_backend/main_v2.py
@@ -7,26 +7,38 @@ from intavia_backend.models_v2 import (
     Entity,
     Event,
     PaginatedResponseEntities,
+    PaginatedResponseEvents,
     PaginatedResponseVocabularyEntries,
     VocabularyEntry,
 )
-from intavia_backend.query_parameters_v2 import Entity_Retrieve, QueryBase, RequestID, Search, SearchVocabs
+from intavia_backend.query_parameters_v2 import (
+    Entity_Retrieve,
+    QueryBase,
+    RequestID,
+    Search,
+    SearchEvents,
+    SearchVocabs,
+)
 from .utils import flatten_rdf_data, get_query_from_triplestore_v2, toggle_urls_encoding
 
 router = APIRouter(route_class=versioned_api_route(2, 0))
 
 
 @router.get(
-    "/api/entity/{entity_id}",
-    response_model=Entity,
+    "/api/event/search",
+    response_model=PaginatedResponseEvents,
     response_model_exclude_none=True,
-    tags=["Entities endpoints"],
-    description="Endpoint that allows to retrive an entity by id.",
+    tags=["Events endpoints"],
+    description="Endpoint that allows to query and retrieve entities including \
+    the node history. Depending on the objects found the return object is \
+        different.",
 )
-async def retrieve_entity_v2(entity_id: str):
-    res = get_query_from_triplestore_v2({"entity_id": toggle_urls_encoding(entity_id)}, "get_entity_v2_1.sparql")
-    # res = FakeList(**{"results": flatten_rdf_data(res)})
-    return {"_results": flatten_rdf_data(res)}
+async def query_events(search: SearchEvents = Depends()):
+    res = get_query_from_triplestore_v2(search, "search_events_v2_1.sparql")
+    res = flatten_rdf_data(res)
+    pages = math.ceil(int(res[0]["count"]) / search.limit) if len(res) > 0 else 0
+    count = int(res[0]["count"]) if len(res) > 0 else 0
+    return {"page": search.page, "count": count, "pages": pages, "results": res}
 
 
 @router.get(
@@ -38,6 +50,19 @@ async def retrieve_entity_v2(entity_id: str):
 )
 async def retrieve_event_v2(event_id: str):
     res = get_query_from_triplestore_v2({"event_id": toggle_urls_encoding(event_id)}, "get_event_v2_1.sparql")
+    # res = FakeList(**{"results": flatten_rdf_data(res)})
+    return {"_results": flatten_rdf_data(res)}
+
+
+@router.get(
+    "/api/entity/{entity_id}",
+    response_model=Entity,
+    response_model_exclude_none=True,
+    tags=["Entities endpoints"],
+    description="Endpoint that allows to retrive an entity by id.",
+)
+async def retrieve_entity_v2(entity_id: str):
+    res = get_query_from_triplestore_v2({"entity_id": toggle_urls_encoding(entity_id)}, "get_entity_v2_1.sparql")
     # res = FakeList(**{"results": flatten_rdf_data(res)})
     return {"_results": flatten_rdf_data(res)}
 

--- a/intavia_backend/models_v2.py
+++ b/intavia_backend/models_v2.py
@@ -244,7 +244,7 @@ class EventEntityRelation(RDFUtilsModelBaseClass):
         ...,
         rdfconfig=FieldConfigurationRDF(path="role_type", encode_function=pp_base64),
     )
-    entity: str = Field(..., rdfconfig=FieldConfigurationRDF(path="entity", encode_function=pp_base64))
+    entity: str = Field(..., rdfconfig=FieldConfigurationRDF(path="entity", encode_function=pp_base64, anchor=True))
 
 
 class VocabularyRelation(RDFUtilsModelBaseClass):
@@ -272,6 +272,10 @@ class PaginatedResponseBase(RDFUtilsModelBaseClass):
 
 class PaginatedResponseEntities(PaginatedResponseBase):
     results: typing.List[Entity] = Field([], rdfconfig=FieldConfigurationRDF(path="results"))
+
+
+class PaginatedResponseEvents(PaginatedResponseBase):
+    results: typing.List[Event] = Field([], rdfconfig=FieldConfigurationRDF(path="results"))
 
 
 class PaginatedResponseVocabularyEntries(PaginatedResponseBase):

--- a/intavia_backend/query_parameters_v2.py
+++ b/intavia_backend/query_parameters_v2.py
@@ -91,6 +91,10 @@ class SearchEventsBase:
     def __post_init__(self):
         if self.related_entities_id is not None:
             self.__setattr__("related_entities_id", [toggle_urls_encoding(x) for x in self.related_entities_id])
+        if self.role_id is not None:
+            self.__setattr__("role_id", [toggle_urls_encoding(x) for x in self.role_id])
+        if self.event_kind_id is not None:
+            self.__setattr__("event_kind_id", [toggle_urls_encoding(x) for x in self.event_kind_id])
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/intavia_backend/query_parameters_v2.py
+++ b/intavia_backend/query_parameters_v2.py
@@ -79,6 +79,21 @@ class QueryBase:
 
 
 @dataclasses.dataclass(kw_only=True)
+class SearchEventsBase:
+    q: str = Query(default=None, max_length=200, description="Searches across labels of all events")
+    related_entities: str = Query(default=None, max_length=200, description="Searches labels of related entities")
+    related_entities_id: typing.List[str] = Query(default=None, description="Searches related entities using IDs")
+    role: str = Query(default=None, max_length=200, description="Searches labels of roles")
+    role_id: typing.List[str] = Query(default=None, description="Searches roles using IDs")
+    event_kind: str = Query(default=None, max_length=200, description="Searches labels of entity kinds")
+    event_kind_id: typing.List[str] = Query(default=None, description="Searches entity kinds using IDs")
+
+    def __post_init__(self):
+        if self.related_entities_id is not None:
+            self.__setattr__("related_entities_id", [toggle_urls_encoding(x) for x in self.related_entities_id])
+
+
+@dataclasses.dataclass(kw_only=True)
 class Search_Base:
     q: str = Query(default=None, max_length=200, description="Searches across labels of all entity proxies")
     occupation: str = Query(default=None, max_length=200, description="Searches the labels of the Occupations")
@@ -145,6 +160,14 @@ class Search(Search_Base, QueryBase, Base):
         default=[DatasetsEnum.APIS, DatasetsEnum.BSampo, DatasetsEnum.BNet, DatasetsEnum.SBI],
     )
     kind: list[EntityTypesEnum] = Query(default=None, description="Limit Query to entity type.")
+
+
+@dataclasses.dataclass(kw_only=True)
+class SearchEvents(SearchEventsBase, QueryBase, Base):
+    datasets: list[DatasetsEnum] = Query(
+        description="Select datasets to limit query to",
+        default=[DatasetsEnum.APIS, DatasetsEnum.BSampo, DatasetsEnum.BNet, DatasetsEnum.SBI],
+    )
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/intavia_backend/sparql/query_events_v2_1.sparql
+++ b/intavia_backend/sparql/query_events_v2_1.sparql
@@ -4,14 +4,14 @@
 ?eventLabel bds:search "{{q}}" .
 {%- endif -%}
 {%- if related_entities -%}
-?event bioc:had_participant_in_role/^bioc:bearer_of/crm:P1_is_identified_by ?related_entity_appellation .
+?event (((bioc:had_participant_in_role|bioc:occured_in_the_presence_of_in_role)/^bioc:bearer_of)|crm:P7_took_place_at)/crm:P1_is_identified_by ?related_entity_appellation .
 ?related_entity_appellation a crm:E33_E41_Linguistic_Appellation .
 ?related_entity_appellation rdfs:label ?related_entity_appellation_label .
 ?related_entity_appellation_label bds:search "{{related_entities}}" .
 {%- endif -%}
 {%- if related_entities_id -%}
     {%- for ent in related_entities_id -%}
-        {?event bioc:had_participant_in_role/^bioc:bearer_of <{{ent}}>}
+        {?event ((bioc:had_participant_in_role|bioc:occured_in_the_presence_of_in_role)/^bioc:bearer_of)|crm:P7_took_place_at <{{ent}}>}
         {% if not loop.last %}UNION{% endif %}
         {%- endfor -%}
 {%- endif -%}
@@ -23,7 +23,11 @@
 {%- endif -%}
 {%- if role_id -%}
     {%- for role in role_id -%}
+        {% if role == 'http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at' %}
+        {?event crm:P7_took_place_at ?place}
+        {% else %}
         {?event bioc:had_participant_in_role <{{role}}>}
+        {% endif %}
         {% if not loop.last %}UNION{% endif %}
         {%- endfor -%}
 {%- endif -%}

--- a/intavia_backend/sparql/query_events_v2_1.sparql
+++ b/intavia_backend/sparql/query_events_v2_1.sparql
@@ -1,0 +1,40 @@
+?event bioc:had_participant_in_role/^bioc:bearer_of ?related_entity .
+{%- if q -%}
+?event rdfs:label ?eventLabel .
+?eventLabel bds:search "{{q}}" .
+{%- endif -%}
+{%- if related_entities -%}
+?event bioc:had_participant_in_role/^bioc:bearer_of/crm:P1_is_identified_by ?related_entity_appellation .
+?related_entity_appellation a crm:E33_E41_Linguistic_Appellation .
+?related_entity_appellation rdfs:label ?related_entity_appellation_label .
+?related_entity_appellation_label bds:search "{{related_entities}}" .
+{%- endif -%}
+{%- if related_entities_id -%}
+    {%- for ent in related_entities_id -%}
+        {?event bioc:had_participant_in_role/^bioc:bearer_of <{{ent}}>}
+        {% if not loop.last %}UNION{% endif %}
+        {%- endfor -%}
+{%- endif -%}
+{%- if role -%}
+?event bioc:had_participant_in_role ?role_query .
+?role_query a ?roleType .
+?roleType rdfs:label ?roleTypeLabel .
+?roleTypeLabel bds:search "{{role}}" .
+{%- endif -%}
+{%- if role_id -%}
+    {%- for role in role_id -%}
+        {?event bioc:had_participant_in_role <{{role}}>}
+        {% if not loop.last %}UNION{% endif %}
+        {%- endfor -%}
+{%- endif -%}
+{%- if event_kind -%}
+?event a ?event_kind .
+?event_kind rdfs:label ?eventKindLabel .
+?eventKindLabel bds:search "{{event_kind}}" .
+{%- endif -%}
+{%- if event_kind_id -%}
+    {%- for event_kind in event_lind_id -%}
+        {?event a <{{event_kind}}>}
+        {% if not loop.last %}UNION{% endif %}
+        {%- endfor -%}
+{%- endif -%}

--- a/intavia_backend/sparql/search_events_v2_1.sparql
+++ b/intavia_backend/sparql/search_events_v2_1.sparql
@@ -1,0 +1,45 @@
+PREFIX bds:  <http://www.bigdata.com/rdf/search#>
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX idm: <https://www.intavia.eu/idm/>
+PREFIX idmcore: <http://www.intavia.eu/idm-core/>
+PREFIX bioc: <http://ldf.fi/schema/bioc/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+SELECT ?event ?role ?entity ?event_label ?role_label ?begin ?end ?time_span_label ?role_type ?event_type ?count
+
+{% for dataset in datasets %}
+FROM <{{dataset.value}}>
+{% endfor %}
+
+WITH {
+SELECT DISTINCT ?event 
+
+{% for dataset in datasets -%}
+FROM <{{dataset.value}}>
+{% endfor %}
+
+WHERE {
+{% include 'query_events_v2_1.sparql' %}
+} ORDER BY ?event
+LIMIT {{limit}}
+{% if _offset > 0 %}OFFSET {{_offset}}{% endif %}
+} AS %query_set
+
+WITH {
+    SELECT (COUNT(DISTINCT ?event) AS ?count)
+
+    {% for dataset in datasets %}
+    FROM <{{dataset.value}}>
+    {% endfor %}
+
+    WHERE {
+        {% include 'query_events_v2_1.sparql' %}
+    }
+} AS %count_set
+
+WHERE {  
+INCLUDE %query_set
+INCLUDE %count_set
+{% include 'retrieve_events_v2_1.sparql' %}
+}

--- a/intavia_backend/utils.py
+++ b/intavia_backend/utils.py
@@ -5,7 +5,7 @@ import os
 from urllib.parse import quote, unquote
 from SPARQLWrapper import SPARQLWrapper, JSON
 from intavia_backend.query_parameters import Search
-from intavia_backend.query_parameters_v2 import QueryBase, Search as SearchV2, SearchVocabs
+from intavia_backend.query_parameters_v2 import QueryBase, Search as SearchV2, SearchEvents, SearchVocabs
 from jinja2 import Environment, FileSystemLoader
 from .conversion import convert_sparql_result
 from SPARQLTransformer import pre_process
@@ -77,7 +77,7 @@ def get_query_from_triplestore(search: Search, sparql_template: str, proto_confi
     return res
 
 
-def get_query_from_triplestore_v2(search: Search | QueryBase, sparql_template: str):
+def get_query_from_triplestore_v2(search: Search | QueryBase | SearchEvents, sparql_template: str):
     """creates the query from the template and the search parameters and returns the json
        from the triplestore. This is v2 and doesnt need the proto config anymore
 
@@ -93,6 +93,7 @@ def get_query_from_triplestore_v2(search: Search | QueryBase, sparql_template: s
         or isinstance(search, SearchV2)
         or isinstance(search, SearchVocabs)
         or isinstance(search, QueryBase)
+        or isinstance(search, SearchEvents)
     ):
         search = asdict(search)
     query_template = jinja_env.get_template(sparql_template).render(**search)


### PR DESCRIPTION
adds a basic events search endpoint.

current filters include:
- label of the event
- related entities label and id
- role label and id
- event kind role and id
