### PR TITLE
fix: removes dates that fail the dateparsing

### DIFF
--- a/intavia_backend/utils.py
+++ b/intavia_backend/utils.py
@@ -130,7 +130,10 @@ def flatten_rdf_data(data: dict) -> list:
                 if "value" in v:
                     if "datatype" in v:
                         if v["datatype"] == "http://www.w3.org/2001/XMLSchema#dateTime":
-                            v["value"] = datetime.datetime.fromisoformat(str(v["value"]).replace("Z", "+00:00"))
+                            try:
+                                v["value"] = datetime.datetime.fromisoformat(str(v["value"]).replace("Z", "+00:00"))
+                            except ValueError:
+                                continue  # FIXME: this is removing dates before 0, should be fixed
                         elif v["datatype"] == "http://www.w3.org/2001/XMLSchema#integer":
                             v["value"] = int(v["value"])
                         elif v["datatype"] == "http://www.w3.org/2001/XMLSchema#boolean":


### PR DESCRIPTION
python does not allow for dates prior 0000. to allow for that we need to move to another library. For the moment we remove dates that fail to parse

fixes #165