### PR TITLE
Feature/177-BNet-Are-entries-for-same-entities-going-to-be-aggregated-into-a-single-entity

### DIFF
--- a/intavia_backend/sparql/add_datasets_v2_1.sparql
+++ b/intavia_backend/sparql/add_datasets_v2_1.sparql
@@ -1,5 +1,9 @@
 FROM <http://www.intavia.eu/idm-classes/>
 FROM <http://www.intavia.eu/idm-core/>
+FROM <http://www.intavia.eu/graphs/provided_persons>
+FROM <http://www.intavia.eu/graphs/provided_groups>
+FROM <http://www.intavia.eu/graphs/provided_places>
+FROM <http://www.intavia.eu/graphs/provided_cho>
 {% for dataset in datasets %}
 FROM <{{dataset.value}}>
 {% endfor %}

--- a/intavia_backend/sparql/entity_type_bindings_v2_1.sparql
+++ b/intavia_backend/sparql/entity_type_bindings_v2_1.sparql
@@ -2,19 +2,40 @@
     {%- for k1 in kind -%}
     {?entity_proxy a {{k1.get_rdf_uri()}}
     BIND("{{k1}}" AS ?entityTypeLabel)}
+    {%- if k1 == 'person' -%}
+        GRAPH <http://www.intavia.eu/graphs/provided_persons> 
+            {?entity_proxy idmcore:proxy_for ?entity .}
+    {%- elif k1 == 'group' -%}
+        GRAPH <http://www.intavia.eu/graphs/provided_groups> 
+            {?entity_proxy idmcore:proxy_for ?entity .}
+    {%- elif k1 == 'place' -%}
+        GRAPH <http://www.intavia.eu/graphs/provided_places> 
+            {?entity_proxy idmcore:proxy_for ?entity .}
+    {%- elif k1 == 'cultural-heritage-object' -%}
+        GRAPH <http://www.intavia.eu/graphs/provided_cho> 
+            {?entity_proxy idmcore:proxy_for ?entity .}
+    {%- endif -%}
         {% if not loop.last %}UNION{% endif %}
     {%- endfor -%}
 {%- else -%}
 {?entity_proxy a idmcore:Person_Proxy 
 BIND("person" AS ?entityTypeLabel)
+GRAPH <http://www.intavia.eu/graphs/provided_persons> 
+     {?entity_proxy idmcore:proxy_for ?entity .}
 } UNION {
 ?entity_proxy a crm:E74_Group 
 BIND("group" AS ?entityTypeLabel)
+GRAPH <http://www.intavia.eu/graphs/provided_groups> 
+     {?entity_proxy idmcore:proxy_for ?entity .}
 } UNION {
 ?entity_proxy a crm:E53_Place 
 BIND("place" AS ?entityTypeLabel)
+GRAPH <http://www.intavia.eu/graphs/provided_places> 
+     {?entity_proxy idmcore:proxy_for ?entity .}
 } UNION {
     ?entity_proxy a idm:CHO_Proxy
     BIND("cultural-heritage-object" AS ?entityTypeLabel)
+GRAPH <http://www.intavia.eu/graphs/provided_cho> 
+     {?entity_proxy idmcore:proxy_for ?entity .}
   }
 {%- endif -%}

--- a/intavia_backend/sparql/entity_type_bindings_v2_1.sparql
+++ b/intavia_backend/sparql/entity_type_bindings_v2_1.sparql
@@ -1,20 +1,20 @@
 {%- if kind -%}
     {%- for k1 in kind -%}
-    {?entity a {{k1.get_rdf_uri()}}
+    {?entity_proxy a {{k1.get_rdf_uri()}}
     BIND("{{k1}}" AS ?entityTypeLabel)}
         {% if not loop.last %}UNION{% endif %}
     {%- endfor -%}
 {%- else -%}
-{?entity a idmcore:Person_Proxy 
+{?entity_proxy a idmcore:Person_Proxy 
 BIND("person" AS ?entityTypeLabel)
 } UNION {
-?entity a crm:E74_Group 
+?entity_proxy a crm:E74_Group 
 BIND("group" AS ?entityTypeLabel)
 } UNION {
-?entity a crm:E53_Place 
+?entity_proxy a crm:E53_Place 
 BIND("place" AS ?entityTypeLabel)
 } UNION {
-    ?entity a idm:CHO_Proxy
+    ?entity_proxy a idm:CHO_Proxy
     BIND("cultural-heritage-object" AS ?entityTypeLabel)
   }
 {%- endif -%}

--- a/intavia_backend/sparql/query_entities_v2_1.sparql
+++ b/intavia_backend/sparql/query_entities_v2_1.sparql
@@ -1,6 +1,4 @@
 ?entity_proxy (crm:P1_is_identified_by/rdfs:label)|rdfs:label ?entityLabel .
-GRAPH <http://www.intavia.eu/graphs/provided_persons> 
-     {?entity_proxy idmcore:person_proxy_for ?entity .}
 {%- if q -%}
 ?entityLabel bds:search "{{q}}" .
 ?entityLabel bds:rank ?score .

--- a/intavia_backend/sparql/query_entities_v2_1.sparql
+++ b/intavia_backend/sparql/query_entities_v2_1.sparql
@@ -1,52 +1,54 @@
-?entity (crm:P1_is_identified_by/rdfs:label)|rdfs:label ?entityLabel .
+?entity_proxy (crm:P1_is_identified_by/rdfs:label)|rdfs:label ?entityLabel .
+GRAPH <http://www.intavia.eu/graphs/provided_persons> 
+     {?entity_proxy idmcore:person_proxy_for ?entity .}
 {%- if q -%}
 ?entityLabel bds:search "{{q}}" .
 ?entityLabel bds:rank ?score .
 {%- endif -%}
 {%- if occupation -%}
-    ?entity bioc:has_occupation ?occupation1 . 
+    ?entity_proxy bioc:has_occupation ?occupation1 . 
     ?occupation1 rdfs:label ?occupationLabel1 .
     ?occupationLabel1 bds:search "{{occupation}}" .
     ?occupationLabel1 bds:matchAllTerms "true" .
 {%- endif -%}
 {%- if occupations_id -%}
     {%- for occ in occupations_id -%}
-        {?entity bioc:has_occupation <{{occ}}>}
+        {?entity_proxy bioc:has_occupation <{{occ}}>}
         {% if not loop.last %}UNION{% endif %}
         {%- endfor -%}
 {%- endif -%}
 {%- if born_before -%}
     ?bornBeforeEvent a crm:E67_Birth .
-    ?bornBeforeEvent crm:P98_brought_into_life ?entity .
+    ?bornBeforeEvent crm:P98_brought_into_life ?entity_proxy .
     ?bornBeforeEvent crm:P4_has_time-span/(crm:P82a_begin_of_the_begin|crm:P82b_end_of_the_end) ?bornBeforeFilter .
     FILTER(?bornBeforeFilter < xsd:dateTime("{{born_before}}"))
 {%- endif -%}
 {%- if born_after -%}
     ?bornAfterEvent a crm:E67_Birth .
-    ?bornAfterEvent crm:P98_brought_into_life ?entity .
+    ?bornAfterEvent crm:P98_brought_into_life ?entity_proxy .
     ?bornAfterEvent crm:P4_has_time-span/(crm:P82a_begin_of_the_begin|crm:P82b_end_of_the_end) ?bornAfterFilter .
     FILTER(?bornAfterFilter > xsd:dateTime("{{born_after}}"))
 {%- endif -%}
 {%- if died_before -%}
     ?diedBeforeEvent a crm:E69_Death .
-    ?diedBeforeEvent crm:P100_was_death_of ?entity .
+    ?diedBeforeEvent crm:P100_was_death_of ?entity_proxy .
     ?diedBeforeEvent crm:P4_has_time-span/(crm:P82a_begin_of_the_begin|crm:P82b_end_of_the_end) ?diedBeforeFilter .
     FILTER(?diedBeforeFilter < xsd:dateTime("{{died_before}}"))
 {%- endif -%}
 {%- if died_after -%}
     ?diedAfterEvent a crm:E69_Death .
-    ?diedAfterEvent crm:P100_was_death_of ?entity .
+    ?diedAfterEvent crm:P100_was_death_of ?entity_proxy .
     ?diedAfterEvent crm:P4_has_time-span/(crm:P82a_begin_of_the_begin|crm:P82b_end_of_the_end) ?diedAfterFilter .
     FILTER(?diedAfterFilter > xsd:dateTime("{{died_after}}"))
 {%- endif -%}
 {%- if gender -%}
-    ?entity bioc:has_gender|bioc:gender bioc:{{gender.name}} .
+    ?entity_proxy bioc:has_gender|bioc:gender bioc:{{gender.name}} .
 {%- endif -%}
 {%- if gender_id -%}
-    ?entity bioc:has_gender|bioc:gender <{{gender_id}}> .
+    ?entity_proxy bioc:has_gender|bioc:gender <{{gender_id}}> .
 {%- endif -%}
 {%- if related_entity -%}
-?entity bioc:bearer_of ?role . ?role ^bioc:had_participant_in_role ?event .
+?entity_proxy bioc:bearer_of ?role . ?role ^bioc:had_participant_in_role ?event .
     ?event (crm:P7_took_place_at|(bioc:had_participant_in_role/^bioc:bearer_of)) ?evEntity .  
         {?evEntity crm:P1_is_identified_by ?evEntityAppelation .
                 ?evEntityAppelation a crm:E33_E41_Linguistic_Appellation .
@@ -55,20 +57,20 @@
     ?evEntityLabel bds:search "{{related_entity}}" .
 {%- endif -%}
 {%- if related_entities_id -%}
-?entity bioc:bearer_of ?role . ?role ^bioc:had_participant_in_role|^bioc:occured_in_the_presence_of_in_role ?event .
+?entity_proxy bioc:bearer_of ?role . ?role ^bioc:had_participant_in_role|^bioc:occured_in_the_presence_of_in_role ?event .
     {%- for entity in related_entities_id -%}
         {?event crm:P7_took_place_at|((bioc:had_participant_in_role|bioc:occured_in_the_presence_of_in_role)/^bioc:bearer_of) <{{entity}}>}
         {% if not loop.last %}UNION{% endif %}
         {%- endfor -%}
 {%- endif -%}
 {%- if event_role -%}
-?entity bioc:bearer_of ?role .
+?entity_proxy bioc:bearer_of ?role .
     ?role a/rdfs:label ?roleLabel .
     ?roleLabel bds:search "{{event_role}}" .
     ?roleLabel bds:matchAllTerms "true" .
 {%- endif -%}
 {%- if event_roles_id -%}
-?entity bioc:bearer_of ?role .
+?entity_proxy bioc:bearer_of ?role .
     {%- for role in event_roles_id -%}
         {?role a <{{role}}>}
         {% if not loop.last %}UNION{% endif %}

--- a/intavia_backend/sparql/retrieve_entities_v2_1.sparql
+++ b/intavia_backend/sparql/retrieve_entities_v2_1.sparql
@@ -1,17 +1,17 @@
 BIND("no label provided" AS ?defaultEntityLabel)
-OPTIONAL {?entity crm:P1_is_identified_by ?appellation .
+OPTIONAL {?entity_proxy crm:P1_is_identified_by ?appellation .
 {?appellation a crm:E33_E41_Linguistic_Appellation .} UNION {?appellation a crm:E35_Title}
 ?appellation rdfs:label ?entityLabelPre .}
-OPTIONAL {?entity bioc:has_occupation ?occupation . ?occupation rdfs:label ?occupationLabel .}
-OPTIONAL {?entity owl:sameAs ?linkedIds}
-OPTIONAL {?entity bioc:has_gender ?gender 
+OPTIONAL {?entity_proxy bioc:has_occupation ?occupation . ?occupation rdfs:label ?occupationLabel .}
+OPTIONAL {?entity_proxy owl:sameAs ?linkedIds}
+OPTIONAL {?entity_proxy bioc:has_gender ?gender 
     OPTIONAL {?gender rdfs:label ?genderLabel }}
-OPTIONAL {?entity bioc:has_nationality ?nationality . ?nationality rdfs:label ?nationalityLabel .}
-OPTIONAL {?entity bioc:bearer_of ?role . 
+OPTIONAL {?entity_proxy bioc:has_nationality ?nationality . ?nationality rdfs:label ?nationalityLabel .}
+OPTIONAL {?entity_proxy bioc:bearer_of ?role . 
         ?role ^bioc:had_participant_in_role|^bioc:occured_in_the_presence_of_in_role ?event .
         ?role a ?role_type
 }
-OPTIONAL {?entity crm:P168_place_is_defined_by/crm:P168_place_is_defined_by ?geometry}
-OPTIONAL {?entity ^crm:P70_documents ?mediaObject }
-OPTIONAL {?entity idmcore:bio_link ?biographyObject }
+OPTIONAL {?entity_proxy crm:P168_place_is_defined_by/crm:P168_place_is_defined_by ?geometry}
+OPTIONAL {?entity_proxy ^crm:P70_documents ?mediaObject }
+OPTIONAL {?entity_proxy idmcore:bio_link ?biographyObject }
 BIND(COALESCE(?entityLabelPre, ?defaultEntityLabel) AS ?entityLabel)

--- a/intavia_backend/sparql/retrieve_events_v2_1.sparql
+++ b/intavia_backend/sparql/retrieve_events_v2_1.sparql
@@ -1,12 +1,14 @@
 ?event a ?event_type .
-  ?event ((bioc:had_participant_in_role|bioc:occured_in_the_presence_of_in_role)/^bioc:bearer_of)|crm:P7_took_place_at ?entity .
+  ?event ((bioc:had_participant_in_role|bioc:occured_in_the_presence_of_in_role)/^bioc:bearer_of)|crm:P7_took_place_at ?entity_proxy .
+  ?entity_proxy idmcore:proxy_for ?entity .
 OPTIONAL {?event rdfs:label ?event_label }
 OPTIONAL {?event bioc:had_participant_in_role|bioc:occured_in_the_presence_of_in_role ?role .
-    ?role ^bioc:bearer_of ?entity .
+    ?role ^bioc:bearer_of ?entity_proxy .
     ?role a ?role_type .
     OPTIONAL {?role rdfs:label ?role_label}
   }
-  OPTIONAL {?event crm:P7_took_place_at ?entity .
+  OPTIONAL {?event crm:P7_took_place_at ?entity_proxy .
+    ?entity_proxy idmcore:proxy_for ?entity .
     BIND("took place at" as ?role_label)
     BIND(crm:P7_took_place_at as ?role_type)
   }

--- a/intavia_backend/sparql/search_v2_1.sparql
+++ b/intavia_backend/sparql/search_v2_1.sparql
@@ -13,7 +13,7 @@ SELECT ?entity ?entityType ?entityTypeLabel ?entityLabel ?gender ?genderLabel ?n
 {% include 'add_datasets_v2_1.sparql' %}
 
 WITH {
-SELECT DISTINCT ?entity ?entityTypeLabel ?score 
+SELECT DISTINCT ?entity ?entityTypeLabel ?score ?entity_proxy 
 
 {% include 'add_datasets_v2_1.sparql' %}
 


### PR DESCRIPTION
moves SPARQL queries to use provided entities instead of proxies

this allows us to combine sameAs entities from several named graphs into one when delivering results via the API.

Currently there are still some issues with the flows that create the provided entities. thus there are less entities than expected.

fixes #177