### PR TITLE
feat: adds sameAs query parameter and filters in SPARQL query

### DIFF
--- a/intavia_backend/query_parameters_v2.py
+++ b/intavia_backend/query_parameters_v2.py
@@ -138,6 +138,9 @@ class Search_Base:
         description="Searches across labels of all entity proxies. When not using quotes, the query will be wildcarded. When using quotes, \
             the query will be exact. Keep in mind that the wildcards will be added right and left of the query (wildcards are not added per token).",
     )
+    sameas: typing.List[HttpUrl] = Query(
+        default=None,
+        description="Searches for a specific entity proxy using sameAs URIs",)
     occupation: str = Query(
         default=None,
         max_length=200,

--- a/intavia_backend/sparql/query_entities_v2_1.sparql
+++ b/intavia_backend/sparql/query_entities_v2_1.sparql
@@ -3,6 +3,12 @@
 ?entityLabel bds:search "{{q}}" .
 ?entityLabel bds:rank ?score .
 {%- endif -%}
+{%- if sameas -%}
+    {%- for uri in sameas -%}
+    {?entity_proxy owl:sameAs <{{uri}}> }
+    {% if not loop.last %}UNION{% endif %}
+    {%- endfor -%}
+{%- endif -%}
 {%- if occupation -%}
     ?entity_proxy bioc:has_occupation ?occupation1 . 
     ?occupation1 rdfs:label ?occupationLabel1 .


### PR DESCRIPTION
Given that we have a vast number of sameAs links in the data, we want to also query for those parameters. This is a naive first approach not taking the normalization problem into account. There will be another issue + PR to approach that problem.

fixes #182